### PR TITLE
set note for include/exclude of parameters

### DIFF
--- a/src/differenceInBusinessDays/index.ts
+++ b/src/differenceInBusinessDays/index.ts
@@ -18,8 +18,8 @@ import { toDate } from "../toDate/index.js";
  *
  * @typeParam DateType - The `Date` type, the function operates on. Gets inferred from passed arguments. Allows to use extensions like [`UTCDate`](https://github.com/date-fns/utc).
  *
- * @param dateLeft - The later date
- * @param dateRight - The earlier date
+ * @param dateLeft - The later date (excluded)
+ * @param dateRight - The earlier date (included)
  *
  * @returns The number of business days
  *


### PR DESCRIPTION
Hey. I created a small fix for the documentation of the differenceInBusinessDays parameters because it was not clear that the first parameter was excluded and so many people have incorrect values for that method like in these issue: https://github.com/date-fns/date-fns/issues/1268

best regards

René